### PR TITLE
Feature/add storage compatability/allow override directories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ tmp_dir=$(mktemp -d)
 # description: allow either directories or files to be specified.
 #   recurse down directories and discover .tf files and pass through
 #   regular files as is.
-# input: json array of files or directories relative to .github
+# input: json array of files or directories relative to the project root
 # output: a json array of the resulting files
 function parse_override_paths() {
   override_input=$1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,6 +16,11 @@ fi
 
 tmp_dir=$(mktemp -d)
 
+# description: allow either directories or files to be specified.
+#   recurse down directories and discover .tf files and pass through
+#   regular files as is.
+# input: json array of files or directories relative to .github
+# output: a json array of the resulting files
 function parse_override_paths() {
   override_input=$1
   override_paths=( $(jq '.[]' -r <<< "${override_input}") )

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,15 +26,15 @@ function parse_override_paths() {
   override_paths=( $(jq '.[]' -r <<< "${override_input}") )
   override_files=()
 
-  for override_file in ${override_paths[@]}; do
-    if [[ -d $override_file ]]; then
+  for override_path in ${override_paths[@]}; do
+    if [[ -d $override_path ]]; then
       while IFS=  read -r -d $'\0'; do
         override_files+=("$REPLY")
-      done < <(find "${override_file}" -type f -name "*.tf" -print0)
-    elif [[ -f $override_file ]]; then
-      override_files+=("${override_file}")
+      done < <(find "${override_path}" -type f -name "*.tf" -print0)
+    elif [[ -f $override_path ]]; then
+      override_files+=("${override_path}")
     else
-      echo "$override_file is not valid"
+      echo "$override_path is not valid"
       exit 1
     fi
   done


### PR DESCRIPTION
    feature: directories can be specified for overrides

      we want this so that we can setup terraform through convention,
      in other words we want to be able to pass in an override like
      `override_files: '[ ".github/terraform/${{ matrix.iaas }}", ".github/terraform/some/specific/file.tf"]'`

      I didn't want to break backwards compatibility so that this is
      can be used as a simple shim

      This is currently untested, but I ran it locally